### PR TITLE
Updated instructions for using non default region (AWS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ The remote state is defined in `aws/main.tf`. Variable interpolation is not allo
 - `region`: The region to use. Default `us-east-1`.
 - `storage_bucket`: The name of the S3 bucket to store the state file in. Default `opencti-storage`.
 
-**Important:** If you change the region in `aws/terraform.tfvars`, you will want to change the region here, too. If you want to change the S3 bucket name (defined in `aws/terraform.tfvars`), you will also want to change it here.
+**Important:**
+
+If you change the region in `aws/terraform.tfvars`, you will want to change the region here, too. Also, when changing the region you will need to update the ami_id in main.tf to the correct ID for the Ubuntu 20.04 LTS 64-bit x86 in your chosen region.
+
+If you want to change the S3 bucket name (defined in `aws/terraform.tfvars`), you will also want to change it here.
 
 ### Azure
 First, change into the `azure/` directory:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The remote state is defined in `aws/main.tf`. Variable interpolation is not allo
 
 **Important:**
 
-If you change the region in `aws/terraform.tfvars`, you will want to change the region here, too. Also, when changing the region you will need to update the ami_id in main.tf to the correct ID for the Ubuntu 20.04 LTS 64-bit x86 in your chosen region.
+If you change the region in `aws/terraform.tfvars`, you will want to change the region here(`aws/main.tf`), too. Also, when changing the region you will need to update the ami_id to the correct ID for the Ubuntu 20.04 LTS 64-bit x86 in your chosen region.
 
 If you want to change the S3 bucket name (defined in `aws/terraform.tfvars`), you will also want to change it here.
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -11,13 +11,16 @@ terraform {
     bucket = "opencti-storage"
     key    = "terraform.tfstate"
     # Again, no variable interpolation in this block so make sure this matches the region defined in `terraform.tfvars`. Default `us-east-1`.
+    # If changing the region, also update the ami_id in the locals section below.
     region = "us-east-1"
   }
 }
 
-# These variables aren't meant to be changed by the end user.
+
 locals {
-  ami_id                         = "ami-0074ee617a234808d" # Ubuntu 20.04 LTS
+  # If changing the region, ensure you update to the id for the ami in your selected region.
+  ami_id                         = "ami-0074ee617a234808d" # Ubuntu 20.04 LTS (64-bit x86)
+  # These variables aren't meant to be changed by the end user.
   opencti_dir                    = "/opt/opencti"
   opencti_install_script_name    = "opencti-installer.sh"
   opencti_connectors_script_name = "opencti-connectors.sh"


### PR DESCRIPTION
During a deployment to the London region in AWS I noticed an error (ami_id not found) having followed the instructions. This update makes it clear that the ami_id set in `main.tf` is region specific and therefore requires updating alongside the region.