### PR TITLE
Updates for OpenCTI 5.3.10 (rabbitmq, grakn/typedb, connectors, redis, and platform)

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region                  = var.region
-  shared_credentials_file = "~/.aws/credentials"
+  shared_credentials_files = ["$HOME/.aws/credentials"]
   profile                 = "default"
 }
 

--- a/aws/storage.tf
+++ b/aws/storage.tf
@@ -1,12 +1,18 @@
 # S3 bucket to store install and connectors scripts.
 resource "aws_s3_bucket" "opencti_bucket" {
   bucket = var.storage_bucket
-  acl    = "private"
+}
 
-  # Turn on bucket versioning. We'll be storing the Terraform state in S3 and versioning will help protect against human error.
-  versioning {
-    enabled = true
-  }
+resource "aws_s3_bucket_versioning" "opencti_bucket_versioning" {
+    bucket = aws_s3_bucket.opencti_bucket.id
+    versioning_configuration {
+        status = "Enabled"
+    }
+}
+
+resource "aws_s3_bucket_acl" "opencti_bucket_acl" {
+    bucket = aws_s3_bucket.opencti_bucket.id
+    acl = "private"
 }
 
 # S3 IAM (I don't think any of these permissions are being used)
@@ -34,14 +40,14 @@ resource "aws_iam_role_policy_attachment" "opencti_s3_attach" {
 }
 
 # OpenCTI installer script
-resource "aws_s3_bucket_object" "opencti-install-script" {
+resource "aws_s3_object" "opencti-install-script" {
   bucket = aws_s3_bucket.opencti_bucket.id
   key    = "opencti-installer.sh"
   source = "../opencti_scripts/installer.sh"
 }
 
 # OpenCTI connectors script
-resource "aws_s3_bucket_object" "opencti-connectors-script" {
+resource "aws_s3_object" "opencti-connectors-script" {
   bucket = aws_s3_bucket.opencti_bucket.id
   key    = "opencti-connectors.sh"
   source = "../opencti_scripts/connectors.sh"

--- a/aws/vm.tf
+++ b/aws/vm.tf
@@ -7,6 +7,9 @@ resource "aws_instance" "opencti_instance" {
   iam_instance_profile        = aws_iam_instance_profile.opencti_profile.name
   root_block_device {
     volume_size = var.root_volume_size
+    volume_type = "gp3"
+    iops = 3000
+    throughput = 125
   }
   subnet_id = var.subnet_id
 

--- a/opencti_scripts/connectors.sh
+++ b/opencti_scripts/connectors.sh
@@ -123,6 +123,10 @@ elif [[ ${ubuntu_version} == 20 ]]
 then
   # Using bionic since focal not avaialble yet for RabbitMQ
   python_ver="3"
+elif [[ ${ubuntu_version} == 22 ]]
+then
+  # Using bionic since focal not avaialble yet for RabbitMQ
+  python_ver="3"
 else
   quit_on_error echo "You are using an unsupported version of Ubuntu. Exiting."
 fi

--- a/opencti_scripts/connectors.sh
+++ b/opencti_scripts/connectors.sh
@@ -201,6 +201,14 @@ do
     fi
 
     sbasename=$(basename "$i")
+    scriptname="$sbasename"
+
+    # Some of the services use the service name as the main Python script name, while
+    # others have started using "main.py". This check attempts to discover which the
+    # service in question is using, and adapts to it, falling back on the old behavior
+    if [[ -f "${opencti_connector_dir}/$i/src/main.py" ]]; then
+        scriptname="main"
+    fi
 
     if [[ ! -f "/etc/systemd/system/opencti-connector-$sbasename.service" ]]
     then
@@ -216,7 +224,7 @@ RestartSec=20
 TimeoutStartSec=600
 Type=simple
 WorkingDirectory=${opencti_connector_dir}/$i/src
-ExecStart=/usr/bin/python${python_ver} "${opencti_connector_dir}/$i/src/$sbasename.py"
+ExecStart=/usr/bin/python${python_ver} "${opencti_connector_dir}/$i/src/$scriptname.py"
 ExecReload=/bin/kill -s HUP \$MAINPID
 ExecStop=/bin/kill -s TERM \$MAINPID
 PrivateTmp=true

--- a/opencti_scripts/connectors.sh
+++ b/opencti_scripts/connectors.sh
@@ -140,26 +140,26 @@ warn_user
 # This will only set up your instance for the connectors enabled. You must supply an API token (e.g., alienvault token) and enable the service.
 # It should be safe to run this after changing configs or enabling services.
 declare -A CONNECTORS;
-CONNECTORS['alienvault']=0
-CONNECTORS['amitt']=0
-CONNECTORS['crowdstrike']=0
-CONNECTORS['cryptolaemus']=0
-CONNECTORS['cve']=1
-CONNECTORS['cyber-threat-coalition']=0
-CONNECTORS['cybercrime-tracker']=0
-CONNECTORS['export-file-csv']=1
-CONNECTORS['export-file-stix']=1
-CONNECTORS['hygiene']=0
-CONNECTORS['import-file-pdf-observables']=1
-CONNECTORS['import-file-stix']=1
-CONNECTORS['ipinfo']=0
-CONNECTORS['lastinfosec']=0
-CONNECTORS['malpedia']=0
-CONNECTORS['misp']=1
-CONNECTORS['mitre']=1
-CONNECTORS['opencti']=1
-CONNECTORS['valhalla']=0
-CONNECTORS['virustotal']=1
+CONNECTORS['external-import/alienvault']=0
+CONNECTORS['external-import/amitt']=0
+CONNECTORS['external-import/crowdstrike']=0
+CONNECTORS['external-import/cryptolaemus']=0
+CONNECTORS['external-import/cve']=1
+CONNECTORS['external-import/cyber-threat-coalition']=0
+CONNECTORS['external-import/cybercrime-tracker']=0
+CONNECTORS['internal-export-file/export-file-csv']=1
+CONNECTORS['internal-export-file/export-file-stix']=1
+CONNECTORS['internal-enrichment/hygiene']=0
+CONNECTORS['internal-import-file/import-document']=1
+CONNECTORS['internal-import-file/import-file-stix']=1
+CONNECTORS['internal-enrichment/ipinfo']=0
+CONNECTORS['external-import/lastinfosec']=0
+CONNECTORS['external-import/malpedia']=0
+CONNECTORS['external-import/misp']=1
+CONNECTORS['external-import/mitre']=1
+CONNECTORS['external-import/opencti']=1
+CONNECTORS['external-import/valhalla']=0
+CONNECTORS['internal-enrichment/virustotal']=1
 
 echo "The following connectors will be installed:"
 for i in "${!CONNECTORS[@]}"
@@ -200,16 +200,18 @@ do
       sed -i"" -e "s/id: 'ChangeMe'/id: '$(uuidgen -r | tr -d '\n' | tr '[:upper:]' '[:lower:]')'/g" "${opencti_connector_dir}/$i/src/config.yml"
     fi
 
-    if [[ ! -f "/etc/systemd/system/opencti-connector-$i.service" ]]
+    sbasename=$(basename "$i")
+
+    if [[ ! -f "/etc/systemd/system/opencti-connector-$sbasename.service" ]]
     then
-      cat > /etc/systemd/system/opencti-connector-$i.service <<- EOT
+      cat > /etc/systemd/system/opencti-connector-$sbasename.service <<- EOT
 [Unit]
 Description=OpenCTI Connector - $i
 After=network.target
 [Service]
 Type=simple
 WorkingDirectory=${opencti_connector_dir}/$i/src
-ExecStart=/usr/bin/python${python_ver} "${opencti_connector_dir}/$i/src/$i.py"
+ExecStart=/usr/bin/python${python_ver} "${opencti_connector_dir}/$i/src/$sbasename.py"
 ExecReload=/bin/kill -s HUP \$MAINPID
 ExecStop=/bin/kill -s TERM \$MAINPID
 PrivateTmp=true
@@ -219,16 +221,16 @@ WantedBy=multi-user.target
 EOT
 
       systemctl daemon-reload
-      systemctl start opencti-connector-$i.service
+      systemctl start opencti-connector-$sbasename.service
     fi
 
-    if [[ $(systemctl status --no-pager opencti-connector-$i.service | grep 'Active: active') ]]
+    if [[ $(systemctl status --no-pager opencti-connector-$sbasename.service | grep 'Active: active') ]]
     then
-      echo "opencti-connector-$i.service is already running, restarting due to config changes"
-      systemctl restart opencti-connector-$i.service
+      echo "opencti-connector-$sbasename.service is already running, restarting due to config changes"
+      systemctl restart opencti-connector-$sbasename.service
     fi
 
-    quit_on_error "Installing service for connector: $i"
+    quit_on_error "Installing service for connector: $sbasename"
   fi
 done
 

--- a/opencti_scripts/connectors.sh
+++ b/opencti_scripts/connectors.sh
@@ -208,7 +208,12 @@ do
 [Unit]
 Description=OpenCTI Connector - $i
 After=network.target
+StartLimitBurst=30
+StartLimitInterval=0
+
 [Service]
+RestartSec=20
+TimeoutStartSec=600
 Type=simple
 WorkingDirectory=${opencti_connector_dir}/$i/src
 ExecStart=/usr/bin/python${python_ver} "${opencti_connector_dir}/$i/src/$sbasename.py"

--- a/opencti_scripts/connectors.sh
+++ b/opencti_scripts/connectors.sh
@@ -158,7 +158,7 @@ CONNECTORS['external-import/malpedia']=0
 CONNECTORS['external-import/misp']=1
 CONNECTORS['external-import/mitre']=1
 CONNECTORS['external-import/opencti']=1
-CONNECTORS['external-import/valhalla']=0
+CONNECTORS['external-import/valhalla']=1
 CONNECTORS['internal-enrichment/virustotal']=1
 
 echo "The following connectors will be installed:"

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -208,7 +208,7 @@ else
 fi
 
 # TypeDB
-typedb_bin_version="2.11.1"
+typedb_bin_version="2.9.0"
 typedb_console_version="2.11.1"
 typedb_core_all_version="2.11.1"
 typedb_core_server_version="2.11.1"
@@ -319,6 +319,8 @@ update_apt_pkg
 # check_apt_pkg 'grakn-bin' "=${grakn_bin_version}"
 # check_apt_pkg 'grakn-core-server' "=${grakn_core_server_version}"
 # check_apt_pkg 'grakn-console' "=${grakn_console_version}"
+check_apt_pkg 'typedb-bin' "=${typedb_bin_version}"
+check_apt_pkg 'typedb-server' "=${typedb_core_all_version}"
 check_apt_pkg 'typedb-all' "=${typedb_core_all_version}"
 
 ### Create systemd unit file for TypeDB

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -237,7 +237,7 @@ do
   esac
 done
 
-opencti_ver="5.3.7"
+opencti_ver="5.3.10"
 opencti_dir="/opt/opencti"
 opencti_worker_count=4
 

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -234,7 +234,7 @@ do
   esac
 done
 
-opencti_ver="5.3.12"
+opencti_ver="5.3.16"
 opencti_dir="/opt/opencti"
 opencti_worker_count=4
 

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -215,7 +215,7 @@ minio_dir="/opt/minio/data"
 redis_ver="6.0.5"
 
 # RabbitMQ
-rabbitmq_ver="3.8.5-1"
+rabbitmq_ver="3.8.34-1"
 rabbitmq_release_url="https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc"
 
 # OpenCTI
@@ -471,13 +471,23 @@ enable_service 'redis-server'
 ## RabbitMQ
 log_section_heading "RabbitMQ"
 curl -fsSL "${rabbitmq_release_url}" | apt-key add -
-tee /etc/apt/sources.list.d/bintray.rabbitmq.list <<EOT
+curl -fsSL https://packagecloud.io/rabbitmq/rabbitmq-server/gpgkey | sudo gpg --dearmor | sudo tee /usr/share/keyrings/rabbitmq_rabbitmq-server-archive-keyring.gpg
+curl -1sLf "https://keys.openpgp.org/vks/v1/by-fingerprint/0A9AF2115F4687BD29803A206B73A36E6026DFCA" | sudo gpg --dearmor | sudo tee /usr/share/keyrings/com.rabbitmq.team.gpg
+curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/gpg.E495BB49CC4BBE5B.key | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg
+curl -1sLf https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/gpg.9F4587F226208342.key | sudo gpg --dearmor | sudo tee /usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg
+tee /etc/apt/sources.list.d/rabbitmq_rabbitmq-server.list <<EOT
 ## Installs the latest Erlang 22.x release.
 ## Change component to "erlang-21.x" to install the latest 21.x version.
 ## "bionic" as distribution name should work for any later Ubuntu or Debian release.
 ## See the release to distribution mapping table in RabbitMQ doc guides to learn more.
-deb [trusted=yes] https://dl.bintray.com/rabbitmq-erlang/debian ${distro} erlang
-deb [trusted=yes] https://dl.bintray.com/rabbitmq/debian ${distro} main
+## deb [trusted=yes] https://dl.bintray.com/rabbitmq-erlang/debian ${distro} erlang
+## deb [trusted=yes] https://dl.bintray.com/rabbitmq/debian ${distro} main
+deb [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu bionic main
+deb-src [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.E495BB49CC4BBE5B.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-erlang/deb/ubuntu bionic main
+deb [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu bionic main
+deb-src [signed-by=/usr/share/keyrings/io.cloudsmith.rabbitmq.9F4587F226208342.gpg] https://dl.cloudsmith.io/public/rabbitmq/rabbitmq-server/deb/ubuntu bionic main
+deb [signed-by=/usr/share/keyrings/rabbitmq_rabbitmq-server-archive-keyring.gpg] https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu focal main
+deb-src [signed-by=/usr/share/keyrings/rabbitmq_rabbitmq-server-archive-keyring.gpg] https://packagecloud.io/rabbitmq/rabbitmq-server/ubuntu focal main
 EOT
 
 update_apt_pkg

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -203,10 +203,10 @@ else
 fi
 
 # TypeDB
-typedb_bin_version="2.11.0"
-typedb_console_version="2.11.0"
-typedb_core_all_version="2.11.0"
-typedb_core_server_version="2.11.0"
+typedb_bin_version="2.11.1"
+typedb_console_version="2.11.1"
+typedb_core_all_version="2.11.1"
+typedb_core_server_version="2.11.1"
 
 # Minio
 minio_dir="/opt/minio/data"

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -232,9 +232,9 @@ do
   esac
 done
 
-opencti_ver="4.2.1"
+opencti_ver="5.3.7"
 opencti_dir="/opt/opencti"
-opencti_worker_count=2
+opencti_worker_count=4
 
 # ###########
 # Main script
@@ -541,8 +541,8 @@ echo "Changing owner of ${opencti_dir} to:" $(whoami)":"$(id -gn)
 chown -R $(whoami):$(id -gn) "${opencti_dir}"
 
 echo "OpenCTI: Installing Python dependencies"
-${run_python} -m pip -q install -r "${opencti_dir}/connectors/export-file-stix/src/requirements.txt"
-${run_python} -m pip -q install -r "${opencti_dir}/connectors/import-file-stix/src/requirements.txt"
+${run_python} -m pip -q install -r "${opencti_dir}/connectors/internal-export-file/export-file-stix/src/requirements.txt"
+${run_python} -m pip -q install -r "${opencti_dir}/connectors/internal-import-file/import-file-stix/src/requirements.txt"
 ${run_python} -m pip -q install -r "${opencti_dir}/src/python/requirements.txt"
 ${run_python} -m pip -q install -r "${opencti_dir}/worker/requirements.txt"
 ${run_python} -m pip install requests==2.25.0

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -457,7 +457,7 @@ Type=notify
 ExecStart=/usr/local/bin/redis-server /etc/redis/redis.conf
 ExecStop=/usr/local/bin/redis-cli -p 6379 shutdown
 ExecReload=/bin/kill -USR2 \$MAINPID
-TimeoutStartSec=10
+TimeoutStartSec=30
 TimeoutStopSec=10
 Restart=on-failure
 [Install]

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -457,7 +457,7 @@ Type=notify
 ExecStart=/usr/local/bin/redis-server /etc/redis/redis.conf
 ExecStop=/usr/local/bin/redis-cli -p 6379 shutdown
 ExecReload=/bin/kill -USR2 \$MAINPID
-TimeoutStartSec=30
+TimeoutStartSec=900
 TimeoutStopSec=10
 Restart=on-failure
 [Install]

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -234,7 +234,7 @@ do
   esac
 done
 
-opencti_ver="5.3.10"
+opencti_ver="5.3.12"
 opencti_dir="/opt/opencti"
 opencti_worker_count=4
 

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -212,7 +212,7 @@ typedb_core_server_version="2.11.0"
 minio_dir="/opt/minio/data"
 
 # Redis
-redis_ver="6.0.5"
+redis_ver="7.0.2"
 
 # RabbitMQ
 rabbitmq_ver="3.8.34-1"
@@ -436,7 +436,7 @@ fi
 if [[ ! -f "/etc/redis/redis.conf" ]]
 then
   cp "redis-${redis_ver}/redis.conf" "/etc/redis/redis.conf"
-  sed -i 's/^supervised no/supervised systemd/' "/etc/redis/redis.conf"
+  sed -i 's/^\#\ supervised\ .*$/supervised auto/' "/etc/redis/redis.conf"
   chown redis:redis "/etc/redis/redis.conf"
 fi
 

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -588,7 +588,12 @@ cat > /etc/systemd/system/opencti-worker@.service <<- EOT
 [Unit]
 Description=OpenCTI Worker daemon %i
 After=network.target opencti-server.service
+StartLimitBurst=30
+StartLimitInterval=0
+
 [Service]
+RestartSec=20
+TimeoutStartSec=600
 Type=simple
 WorkingDirectory=${opencti_dir}/worker/
 ExecStart=/usr/bin/${run_python} "${opencti_dir}/worker/worker.py"

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -214,7 +214,7 @@ typedb_core_all_version="2.11.1"
 typedb_core_server_version="2.11.1"
 
 # Redis
-redis_ver="7.0.2"
+redis_ver="7.0.5"
 
 # RabbitMQ
 rabbitmq_ver="3.10.5-1"
@@ -234,7 +234,7 @@ do
   esac
 done
 
-opencti_ver="5.3.16"
+opencti_ver="5.3.17"
 opencti_dir="/opt/opencti"
 opencti_worker_count=4
 

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -126,7 +126,7 @@ function check_apt_pkg {
 }
 
 # Function: check_service
-# Checks if a service is active or nah. Matches Grakn service output.
+# Checks if a service is active or nah. Matches TypeDB service output.
 # Parameters:
 # - $1: service to check
 function check_service {
@@ -202,11 +202,11 @@ else
   quit_on_error echo "You are using an unsupported version of Ubuntu. Exiting."
 fi
 
-# Grakn
-grakn_bin_version="2.0.0-alpha-6"
-grakn_console_version="2.0.0-alpha-4"
-grakn_core_all_version="2.0.0-alpha-4"
-grakn_core_server_version="2.0.0-alpha-4"
+# TypeDB
+typedb_bin_version="2.11.0"
+typedb_console_version="2.11.0"
+typedb_core_all_version="2.11.0"
+typedb_core_server_version="2.11.0"
 
 # Minio
 minio_dir="/opt/minio/data"
@@ -263,7 +263,7 @@ disable_service 'elasticsearch'
 disable_service 'redis-server'
 disable_service 'rabbitmq-server'
 disable_service 'minio'
-disable_service 'grakn'
+disable_service 'typedb'
 
 # The VMs we're running are not that big and we're going to quickly fill the system log with our work (and especially the connectors). This will max out the logs at 100M.
 echo "SystemMaxUse=100M" >> /etc/systemd/journald.conf
@@ -304,34 +304,34 @@ check_apt_pkg "python3-pip"
 ${run_python} -m pip install --upgrade pip
 ${run_python} -m pip -q install --ignore-installed PyYAML
 
-## Grakn
-log_section_heading "Grakn"
+## TypeDB
+log_section_heading "TypeDB"
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 8F3DA4B5E9AEF44C
-sudo add-apt-repository 'deb [ arch=all ] https://repo.grakn.ai/repository/apt/ trusty main'
+sudo add-apt-repository 'deb [ arch=all ] https://repo.vaticle.com/repository/apt/ trusty main'
 update_apt_pkg
 # apt-get install -y grakn-console=2.0.0-alpha-3 # Required dependency
 # apt-get install -y grakn-core-all
-check_apt_pkg 'grakn-bin' "=${grakn_bin_version}"
-check_apt_pkg 'grakn-core-server' "=${grakn_core_server_version}"
-check_apt_pkg 'grakn-console' "=${grakn_console_version}"
-check_apt_pkg 'grakn-core-all' "=${grakn_core_all_version}"
+# check_apt_pkg 'grakn-bin' "=${grakn_bin_version}"
+# check_apt_pkg 'grakn-core-server' "=${grakn_core_server_version}"
+# check_apt_pkg 'grakn-console' "=${grakn_console_version}"
+check_apt_pkg 'typedb-all' "=${typedb_core_all_version}"
 
-### Create systemd unit file for Grakn
-cat <<EOT > /etc/systemd/system/grakn.service
+### Create systemd unit file for TypeDB
+cat <<EOT > /etc/systemd/system/typedb.service
 [Unit]
-Description=Grakn.AI Server daemon
+Description=TypeDB Server daemon
 After=network.target
 [Service]
-Type=forking
-ExecStart=/usr/local/bin/grakn server start
-ExecStop=/usr/local/bin/grakn server stop
-ExecReload=/usr/local/bin/grakn server stop && /usr/local/bin/grakn server start
-RemainAfterExit=yes
+Type=simple
+ExecStart=/usr/local/bin/typedb server
+#ExecStop=/usr/local/bin/typedb server stop
+#ExecReload=/usr/local/bin/typedb server stop && /usr/local/bin/typedb server start
+#RemainAfterExit=yes
 [Install]
 WantedBy=multi-user.target
 EOT
 systemctl daemon-reload
-enable_service 'grakn'
+enable_service 'typedb'
 
 ## Elasticsearch
 log_section_heading "Elasticsearch"
@@ -514,7 +514,7 @@ echo -e "${RMQ_user_list}"
 # Check status of services
 log_section_heading "Checking service statuses"
 check_service 'elasticsearch'
-check_service 'grakn'
+check_service 'typedb'
 check_service 'minio'
 check_service 'rabbitmq-server'
 check_service 'redis-server'

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -215,7 +215,7 @@ minio_dir="/opt/minio/data"
 redis_ver="7.0.2"
 
 # RabbitMQ
-rabbitmq_ver="3.8.34-1"
+rabbitmq_ver="3.10.5-1"
 rabbitmq_release_url="https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc"
 
 # OpenCTI

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -198,6 +198,11 @@ then
   # Using bionic since focal not avaialble yet for RabbitMQ
   distro="bionic"
   run_python="python3"
+elif [[ ${ubuntu_version} == 22 ]]
+then
+  # Using bionic since focal not avaialble yet for RabbitMQ
+  distro="bionic"
+  run_python="python3"
 else
   quit_on_error echo "You are using an unsupported version of Ubuntu. Exiting."
 fi

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -358,9 +358,12 @@ cat <<EOT > /etc/logrotate.d/elasticsearch
 }
 EOT
 wget -qO - 'https://artifacts.elastic.co/GPG-KEY-elasticsearch' | apt-key add -
-add-apt-repository "deb https://artifacts.elastic.co/packages/7.x/apt stable main"
+add-apt-repository "deb https://artifacts.elastic.co/packages/8.x/apt stable main"
 update_apt_pkg
 check_apt_pkg 'elasticsearch'
+sed -i 's|xpack.security.enabled: true|xpack.security.enabled: false|' /etc/elasticsearch/elasticsearch.yml
+sed -i 's|xpack.security.enrollment.enabled: true|xpack.security.enrollment.enabled: false|' /etc/elasticsearch/elasticsearch.yml
+sed -i 's|^  enabled: true|  enabled: false|' /etc/elasticsearch/elasticsearch.yml
 enable_service 'elasticsearch'
 
 ## Minio

--- a/opencti_scripts/installer.sh
+++ b/opencti_scripts/installer.sh
@@ -368,7 +368,8 @@ enable_service 'elasticsearch'
 
 ## Minio
 log_section_heading "Minio"
-wget --quiet -O minio https://dl.min.io/server/minio/release/linux-amd64/minio
+my_minio_arch=`uname -m | sed s/aarch64/arm64/g | sed s/x86_64/amd64/g`
+wget --quiet -O minio https://dl.min.io/server/minio/release/linux-${my_minio_arch}/minio
 chmod +x minio
 mv minio "/usr/local/bin/"
 if [[ ! -d "${minio_dir}" ]]

--- a/userdata/installation-wrapper-script.sh
+++ b/userdata/installation-wrapper-script.sh
@@ -41,10 +41,10 @@ chmod +x /opt/${connectors_script_name}
 echo "Starting OpenCTI installation script"
 # Run the install script with the provided e-mail address.
 # AWS automatically runs the script as root, Azure doesn't.
-sudo /opt/${install_script_name} -e "${login_email}"
+sudo /usr/bin/env storage_bucket="${storage_bucket}" /opt/${install_script_name} -e "${login_email}"
 echo "OpenCTI installation script complete."
 
 echo "Starting OpenCTI connectors script."
 # Run the script without prompting the user (the default, `-p 0`, will prompt if the user wants to apply; this is less than ideal for an automated script).
-sudo /opt/${connectors_script_name} -p 1
+sudo /usr/bin/env storage_bucket="${storage_bucket}" /opt/${connectors_script_name} -p 1
 echo "OpenCTI wrapper script complete."


### PR DESCRIPTION
This fixes the RabbitMQ install failure (outdated version/repo), Grakn install failure (it is now TypeDB), and also updates to the latest (5.3.7) version of OpenCTI, properly adapting the connector-specific code to handle the new subdirectories

Potentially resolves #22, #27, #25, #29, #21