### PR TITLE
Fixes #9 - Adding internet gateway to fix SSM issues.

### DIFF
--- a/aws/network.tf
+++ b/aws/network.tf
@@ -1,28 +1,54 @@
 # This code creates a VPC and Subnet. The code applies just fine. But Systems Manager (SSM) is unusable. Says something isn't right. Been tracking it down for far too long and it's outside the scope of this change anyway so commenting and moving along. This VPC/Subnet issue is tracked in #9.
-# resource "aws_vpc" "opencti_vpc" {
-#   cidr_block = "10.1.0.0/16"
+resource "aws_vpc" "opencti_vpc" {
+  cidr_block = "10.1.0.0/16"
 
-#   tags = {
-#     Name = "OpenCTI VPC"
-#   }
-# }
+  tags = {
+    Name = "OpenCTI VPC"
+  }
+}
 
-# resource "aws_subnet" "opencti_subnet" {
-#   vpc_id            = aws_vpc.opencti_vpc.id
-#   cidr_block        = "10.1.10.0/24"
-#   availability_zone = var.availability_zone
+resource "aws_subnet" "opencti_subnet" {
+  vpc_id            = aws_vpc.opencti_vpc.id
+  cidr_block        = "10.1.10.0/24"
+  availability_zone = var.availability_zone
 
-#   tags = {
-#     Name = "OpenCTI subnet"
-#   }
-# }
+  tags = {
+    Name = "OpenCTI subnet"
+  }
+}
 
-# resource "aws_network_interface" "opencti_nic" {
-#   subnet_id   = aws_subnet.opencti_subnet.id
-#   # private_ips = ["10.1.10.100"]
-#   security_groups = [ aws_security_group.opencti_sg.id ]
+resource "aws_internet_gateway" "opencti_gw" {
+  vpc_id = aws_vpc.opencti_vpc.id
 
-#   tags = {
-#     Name = "primary_network_interface"
-#   }
-# }
+  tags = {
+    Name = "opencti_internet_gateway"
+  }
+}
+
+resource "aws_route_table" "opencti_rt" {
+  vpc_id = aws_vpc.opencti_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.opencti_gw.id
+  }
+
+  tags = {
+    Name = "opencti_route_table"
+  }
+}
+
+resource "aws_route_table_association" "opencti_route_assoc" {
+  subnet_id      = aws_subnet.opencti_subnet.id
+  route_table_id = aws_route_table.opencti_rt.id
+}
+
+resource "aws_network_interface" "opencti_nic" {
+  subnet_id = aws_subnet.opencti_subnet.id
+  # private_ips = ["10.1.10.100"]
+  security_groups = [aws_security_group.opencti_sg.id]
+
+  tags = {
+    Name = "primary_network_interface"
+  }
+}

--- a/aws/security_group.tf
+++ b/aws/security_group.tf
@@ -1,7 +1,7 @@
 # Security group
 resource "aws_security_group" "opencti_sg" {
   name   = "opencti_sg"
-  vpc_id = var.vpc_id
+  vpc_id = aws_vpc.opencti_vpc.id
 
   ingress {
     description = "Allow access to application on port 4000"

--- a/aws/terraform.tfvars
+++ b/aws/terraform.tfvars
@@ -5,5 +5,3 @@ login_email = "login.email@example.com"
 # region = "us-east-1"
 # root_volume_size = 32
 # storage_bucket = "opencti-storage"
-subnet_id = ""
-vpc_id = ""

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -39,13 +39,3 @@ variable "storage_bucket" {
   type        = string
   default     = "opencti-storage"
 }
-
-variable "subnet_id" {
-  description = "The subnet ID to use."
-  type        = string
-}
-
-variable "vpc_id" {
-  description = "The VPC ID to use."
-  type        = string
-}

--- a/aws/vm.tf
+++ b/aws/vm.tf
@@ -8,7 +8,7 @@ resource "aws_instance" "opencti_instance" {
   root_block_device {
     volume_size = var.root_volume_size
   }
-  subnet_id = var.subnet_id
+  subnet_id = aws_subnet.opencti_subnet.id
 
   # The wrapper script is used by each of the providers and each variable has to be filled out in order to run. Unfortunately, this means that if you change something in one provider, you have to change it in each of the others. It's not ideal, but FYI.
   user_data = templatefile("../userdata/installation-wrapper-script.sh", {


### PR DESCRIPTION
Fixes #9 

After deploying, ran Reach Analyzer and saw that the instance couldn't reach port 443 for any of the [AWS SSM Endpoints.](https://docs.aws.amazon.com/general/latest/gr/ssm.html). It failed at the route table. Examination of the route table showed no access to the public internet, so adding an internet gateway and a new route table entry fixes it.

Closed my previous PR because I had some variables that weren't needed.